### PR TITLE
chore: activate "dev" profile for im-manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 ENVIRONMENT=<name-of-your-environment>
-CLASSIFICATION=dev
+CLASSIFICATION=feature
 API_HOSTNAME=$ENVIRONMENT.api.im.dhis2.org
 API_URL=https://$ENVIRONMENT.api.im.dhis2.org
 UI_HOSTNAME=$ENVIRONMENT.im.dhis2.org

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ satisfying the path locations.
 
 Copy .env.example to .env
 
-Update the ENVIRONMENT to match your environment
+Update the `ENVIRONMENT` and `CLASSIFICATION` variables to match your environment.
 
 Run `skaffold dev`
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,8 +1,10 @@
-apiVersion: skaffold/v2beta25
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: im-cluster-dev
 requires:
   - path: ../im-manager/skaffold.yaml
+    activeProfiles:
+      - name: dev
   - path: ../im-web-client/skaffold.yaml
   - path: ../im-inspector/skaffold.yaml


### PR DESCRIPTION
In order to deploy all the apps with a single `skaffold dev` command without any extra options, we need to activate the `dev` profile for the im-manager.

Also updates the README and .env.example to match the current setup.